### PR TITLE
Improve core module import fallback

### DIFF
--- a/code/pack.py
+++ b/code/pack.py
@@ -98,10 +98,11 @@ a = Analysis(
     pathex=['.'],
     binaries=[],
     datas=[
-        ('ui', 'ui'),
-        ('core', 'core'),
-        ('utils', 'utils'),
-        ('handlers', 'handlers'),
+        ('ui', 'code/ui'),
+        ('core', 'code/core'),
+        ('utils', 'code/utils'),
+        ('handlers', 'code/handlers'),
+        ('__init__.py', 'code/__init__.py'),
     ],
     hiddenimports=[
         'yaml',


### PR DESCRIPTION
## Summary
- support imports when code package prefix is missing

## Testing
- `python -m py_compile code/main.py code/pack.py`