### PR TITLE
Fix pack script imports

### DIFF
--- a/YAMLWeave_20250516.spec
+++ b/YAMLWeave_20250516.spec
@@ -2,9 +2,7 @@
 import sys
 import os
 from pathlib import Path
-from PyInstaller.utils.hooks import collect_tk_files
-# 收集 Tkinter/TTK 资源，确保主题文件在打包后可用
-tk_binaries, tk_datas = collect_tk_files()
+# 由 PyInstaller 内置钩子自动收集 Tk 相关资源
 
 # 获取项目根目录的绝对路径
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -25,20 +23,19 @@ a = Analysis(
     [os.path.join(CODE_DIR, 'main.py')],
     pathex=[PROJECT_ROOT, CODE_DIR],
 
-    # 把 Tkinter 相关二进制一起打进去
-    binaries=tk_binaries,
+    # Tkinter 二进制由内置钩子自动处理
+    binaries=[],
 
-    # Tk 资源 + 你自定义的额外资源
-    datas=tk_datas + extra_datas,
-)
-        (os.path.join(CODE_DIR, 'ui'), 'code/ui'),  # 使用相对结构
+    # Tk 资源由内置钩子自动处理
+    datas=[
+        (os.path.join(CODE_DIR, 'ui'), 'code/ui'),
         (os.path.join(CODE_DIR, 'core'), 'code/core'),
         (os.path.join(CODE_DIR, 'utils'), 'code/utils'),
         (os.path.join(CODE_DIR, 'handlers'), 'code/handlers'),
         (os.path.join(PROJECT_ROOT, 'samples'), 'samples'),
-        (os.path.join(PROJECT_ROOT, '__init__.py'), '__init__.py'),  # 包含项目根目录的__init__.py
-        (os.path.join(CODE_DIR, '__init__.py'), 'code/__init__.py'),  # 包含code目录的__init__.py
-    ] + tk_datas,
+        (os.path.join(PROJECT_ROOT, '__init__.py'), '__init__.py'),
+        (os.path.join(CODE_DIR, '__init__.py'), 'code/__init__.py'),
+    ] + extra_datas,
     hiddenimports=[
         'code', 'code.ui', 'code.ui.app_ui', 'code.ui.app_controller', 
         'code.core', 'code.core.stub_processor', 'code.core.stub_parser', 'code.core.utils',


### PR DESCRIPTION
## Summary
- remove obsolete `collect_tk_files` import and usage in `pack.py`
- rely on PyInstaller's builtin hooks for Tk
- update legacy spec to avoid missing hook

## Testing
- `python -m py_compile $(git ls-files '*.py')`