### PR TITLE
Fix logging imports for packaged app

### DIFF
--- a/code/core/stub_parser.py
+++ b/code/core/stub_parser.py
@@ -14,11 +14,18 @@ from typing import List, Dict, Any, Optional, Tuple
 
 # 导入日志工具
 try:
-    from YAMLWeave.utils.logger import get_logger
+    from ..utils.logger import get_logger
+except Exception:
+    try:
+        from utils.logger import get_logger
+    except Exception:
+        import logging
+        get_logger = None
+        logger = logging.getLogger(__name__)
+
+if get_logger:
     logger = get_logger(__name__)
-except ImportError:
-    import logging
-    logger = logging.getLogger(__name__)
+if not logger.handlers:
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
@@ -26,19 +33,20 @@ except ImportError:
 
 # 导入YAML处理器
 try:
-    from YAMLWeave.handlers.yaml_handler import YamlStubHandler
-except ImportError:
-    logger.error("无法导入YamlStubHandler，锚点与桩代码分离功能将不可用")
-    YamlStubHandler = None
+    from ..handlers.yaml_handler import YamlStubHandler
+except Exception:
+    try:
+        from handlers.yaml_handler import YamlStubHandler
+    except Exception:
+        logger.error("无法导入YamlStubHandler，锚点与桩代码分离功能将不可用")
+        YamlStubHandler = None
 
 # 导入文件处理工具函数
 try:
-    # 尝试从YAMLWeave包导入
-    from YAMLWeave.core.utils import read_file, write_file
-except ImportError:
+    from ..core.utils import read_file, write_file
+except Exception:
     try:
-        # 尝试从当前目录导入
-        from utils import read_file, write_file
+        from code.core.utils import read_file, write_file
     except ImportError:
         try:
             # 尝试相对导入

--- a/code/core/utils.py
+++ b/code/core/utils.py
@@ -9,10 +9,15 @@ import os
 import logging
 
 try:
-    from YAMLWeave.utils.logger import get_logger
-    logger = get_logger(__name__)
-except ImportError:
-    logger = logging.getLogger(__name__)
+    from ..utils.logger import get_logger
+except Exception:
+    try:
+        from utils.logger import get_logger
+    except Exception:
+        get_logger = None
+
+logger = get_logger(__name__) if get_logger else logging.getLogger(__name__)
+if not logger.handlers:
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))

--- a/code/handlers/comment_handler.py
+++ b/code/handlers/comment_handler.py
@@ -8,10 +8,15 @@ import logging
 from typing import Dict, List, Tuple, Optional, Any
 
 try:
-    from YAMLWeave.utils.logger import get_logger
-    logger = get_logger(__name__)
-except ImportError:
-    logger = logging.getLogger(__name__)
+    from ..utils.logger import get_logger
+except Exception:
+    try:
+        from utils.logger import get_logger
+    except Exception:
+        get_logger = None
+
+logger = get_logger(__name__) if get_logger else logging.getLogger(__name__)
+if not logger.handlers:
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))

--- a/code/handlers/yaml_handler.py
+++ b/code/handlers/yaml_handler.py
@@ -11,11 +11,18 @@ import yaml
 from typing import Dict, List, Any, Optional, Tuple
 
 try:
-    from YAMLWeave.utils.logger import get_logger
+    from ..utils.logger import get_logger
+except Exception:
+    try:
+        from utils.logger import get_logger
+    except Exception:
+        import logging
+        get_logger = None
+        logger = logging.getLogger(__name__)
+
+if get_logger:
     logger = get_logger(__name__)
-except ImportError:
-    import logging
-    logger = logging.getLogger(__name__)
+if not logger.handlers:
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))

--- a/code/pack.py
+++ b/code/pack.py
@@ -75,6 +75,14 @@ def clean_old_files():
             logger.info(f"删除spec文件: {file}")
             os.remove(os.path.join(SCRIPT_DIR, file))
 
+    # 递归删除 __pycache__ 目录，避免旧的字节码被打包
+    for root, dirs, _ in os.walk(PROJECT_DIR):
+        for d in dirs:
+            if d == "__pycache__":
+                pycache_path = os.path.join(root, d)
+                logger.info(f"删除__pycache__目录: {pycache_path}")
+                shutil.rmtree(pycache_path, ignore_errors=True)
+
 def generate_version():
     """生成带时间戳的版本号"""
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/code/utils/config.py
+++ b/code/utils/config.py
@@ -7,8 +7,19 @@ import os
 import yaml
 from typing import Dict, Any, List, Optional
 
-from YAMLWeave.utils.logger import get_logger
-from YAMLWeave.utils.exceptions import ConfigError
+# 尝试相对导入以兼容打包后的路径结构
+try:
+    from .logger import get_logger
+    from .exceptions import ConfigError
+except Exception:  # pragma: no cover - 回退到绝对导入
+    try:
+        from utils.logger import get_logger
+        from utils.exceptions import ConfigError
+    except Exception:
+        import logging
+        get_logger = lambda name=None: logging.getLogger(name)
+        class ConfigError(Exception):
+            pass
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- switch utility modules to relative imports with fallbacks
- allow handlers and parsers to resolve logger regardless of package path

## Testing
- `python -m py_compile $(git ls-files '*.py')`