### PR TITLE
Fix logging error

### DIFF
--- a/code/core/stub_parser.py
+++ b/code/core/stub_parser.py
@@ -10,6 +10,7 @@
 
 import re
 import os
+import logging
 from typing import List, Dict, Any, Optional, Tuple
 
 # 导入日志工具
@@ -19,7 +20,6 @@ except Exception:
     try:
         from utils.logger import get_logger
     except Exception:
-        import logging
         get_logger = None
         logger = logging.getLogger(__name__)
 

--- a/code/handlers/yaml_handler.py
+++ b/code/handlers/yaml_handler.py
@@ -8,6 +8,7 @@ YAML处理器模块
 
 import os
 import yaml
+import logging
 from typing import Dict, List, Any, Optional, Tuple
 
 try:
@@ -16,7 +17,6 @@ except Exception:
     try:
         from utils.logger import get_logger
     except Exception:
-        import logging
         get_logger = None
         logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix NameError from missing logging imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python code/main.py > /tmp/main_output.log 2>&1`