### PR TITLE
Fix logging error

### DIFF
--- a/code/core/stub_parser.py
+++ b/code/core/stub_parser.py
@@ -10,6 +10,7 @@
 
 import re
 import os
+import logging
 from typing import List, Dict, Any, Optional, Tuple
 
 # 导入日志工具
@@ -19,7 +20,6 @@ except Exception:
     try:
         from utils.logger import get_logger
     except Exception:
-        import logging
         get_logger = None
         logger = logging.getLogger(__name__)
 

--- a/code/handlers/yaml_handler.py
+++ b/code/handlers/yaml_handler.py
@@ -8,6 +8,7 @@ YAML处理器模块
 
 import os
 import yaml
+import logging
 from typing import Dict, List, Any, Optional, Tuple
 
 try:
@@ -16,7 +17,6 @@ except Exception:
     try:
         from utils.logger import get_logger
     except Exception:
-        import logging
         get_logger = None
         logger = logging.getLogger(__name__)
 

--- a/code/pack.py
+++ b/code/pack.py
@@ -98,37 +98,44 @@ def create_spec_file(version):
     
     # 使用简单的相对路径，避免转义问题
     spec_content = f"""# -*- mode: python ; coding: utf-8 -*-
+import sys
+import os
+
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
+CODE_DIR = os.path.join(PROJECT_ROOT, 'code')
+sys.path.insert(0, PROJECT_ROOT)
+sys.path.insert(0, CODE_DIR)
 
 block_cipher = None
 
 a = Analysis(
     ['{MAIN_SCRIPT}'],
-    pathex=['.'],
+    pathex=[PROJECT_ROOT, CODE_DIR],
     binaries=[],
     datas=[
-        ('ui', 'code/ui'),
-        ('core', 'code/core'),
-        ('utils', 'code/utils'),
-        ('handlers', 'code/handlers'),
-        ('__init__.py', 'code/__init__.py'),
+        (os.path.join(CODE_DIR, 'ui'), 'code/ui'),
+        (os.path.join(CODE_DIR, 'core'), 'code/core'),
+        (os.path.join(CODE_DIR, 'utils'), 'code/utils'),
+        (os.path.join(CODE_DIR, 'handlers'), 'code/handlers'),
+        (os.path.join(PROJECT_ROOT, '__init__.py'), '__init__.py'),
+        (os.path.join(CODE_DIR, '__init__.py'), 'code/__init__.py'),
     ],
     hiddenimports=[
-        'yaml',
-        'tkinter',
-        'tkinter.filedialog',
-        'tkinter.messagebox',
+        'code', 'code.ui', 'code.ui.app_ui', 'code.ui.app_controller',
+        'code.core', 'code.core.stub_processor', 'code.core.stub_parser', 'code.core.utils',
+        'code.utils', 'code.utils.logger', 'code.utils.exceptions',
+        'code.handlers', 'code.handlers.comment_handler', 'code.handlers.yaml_handler',
+        'yaml', 'tkinter', 'tkinter.filedialog', 'tkinter.messagebox', 'pathlib', 'datetime'
     ],
     hookspath=[],
     hooksconfig={{}},
     runtime_hooks=[],
     excludes=[],
-    win_no_prefer_redirects=False,
-    win_private_assemblies=False,
-    cipher=block_cipher,
     noarchive=False,
+    optimize=0,
 )
 
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+pyz = PYZ(a.pure)
 
 exe = EXE(
     pyz,
@@ -152,7 +159,6 @@ exe = EXE(
 coll = COLLECT(
     exe,
     a.binaries,
-    a.zipfiles,
     a.datas,
     strip=False,
     upx=True,


### PR DESCRIPTION
## Summary
- fix NameError from missing logging imports
- improve PyInstaller spec generation to preserve package imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python code/main.py > /tmp/main_output.log 2>&1`