### PR TITLE
Fix pack script spec generation

### DIFF
--- a/code/pack.py
+++ b/code/pack.py
@@ -101,7 +101,7 @@ def create_spec_file(version):
 import sys
 import os
 
-PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
+PROJECT_ROOT = r"{PROJECT_DIR}"
 CODE_DIR = os.path.join(PROJECT_ROOT, 'code')
 sys.path.insert(0, PROJECT_ROOT)
 sys.path.insert(0, CODE_DIR)
@@ -120,7 +120,7 @@ a = Analysis(
         (os.path.join(PROJECT_ROOT, '__init__.py'), '__init__.py'),
         (os.path.join(CODE_DIR, '__init__.py'), 'code/__init__.py'),
     ],
-hiddenimports = [
+    hiddenimports=[
     # ── 应用自身 ───────────────────────────────────────────────
     'code', 'code.ui', 'code.ui.app_ui', 'code.ui.app_controller',
     'code.core', 'code.core.stub_processor', 'code.core.stub_parser', 'code.core.utils',
@@ -132,8 +132,6 @@ hiddenimports = [
     'tkinter', 'tkinter.filedialog', 'tkinter.messagebox',
     'tkinter.ttk', 'tkinter.scrolledtext', 'tkinter.font',
     'pathlib', 'datetime',
-]
-
     ],
     hookspath=[],
     hooksconfig={{}},


### PR DESCRIPTION
## Summary
- fix `pack.py` spec generation
- ensure `hiddenimports` closing bracket is written correctly
- embed absolute project path so PyInstaller spec doesn't rely on `__file__`

## Testing
- `python3 -m py_compile code/pack.py`
- `python3 code/pack.py` *(fails: missing executable on Linux but spec compiled successfully)*