### PR TITLE
Fix spec generation path quoting

### DIFF
--- a/scripts/build_exe.py
+++ b/scripts/build_exe.py
@@ -111,7 +111,7 @@ sys.path.insert(0, CODE_DIR)
 block_cipher = None
 
 a = Analysis(
-    ['{MAIN_SCRIPT_PATH}'],
+    [r"{MAIN_SCRIPT_PATH}"],
     pathex=[PROJECT_ROOT, CODE_DIR],
     binaries=[],
     datas=[


### PR DESCRIPTION
## Summary
- fix quoting of MAIN_SCRIPT_PATH in generated spec file

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_b_68479995b1dc8321936c0ce682e04d10