### PR TITLE
改进safe_push脚本逻辑

### DIFF
--- a/scripts/safe_push.py
+++ b/scripts/safe_push.py
@@ -6,10 +6,23 @@ MAX_ATTEMPTS = 100
 DELAY_SECONDS = 1
 
 
-def safe_push():
+def safe_push(message: str = "更新脚本快速更新") -> None:
+    try:
+        subprocess.run(["git", "add", "-A"], check=True)
+        result = subprocess.run(["git", "diff", "--cached", "--quiet"])
+        has_changes = result.returncode != 0
+        if has_changes:
+            subprocess.run(["git", "commit", "-m", message], check=True)
+        else:
+            print("No changes to commit.")
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to stage or commit changes: {exc}")
+        sys.exit(1)
+
     for attempt in range(1, MAX_ATTEMPTS + 1):
         try:
-            print(f"Attempt {attempt} to push changes...")
+            print(f"Attempt {attempt} to pull and push changes...")
+            subprocess.run(["git", "pull", "--rebase"], check=True)
             subprocess.run(["git", "push"], check=True)
             print("Push successful.")
             return
@@ -21,4 +34,5 @@ def safe_push():
 
 
 if __name__ == "__main__":
-    safe_push()
+    msg = sys.argv[1] if len(sys.argv) > 1 else "更新脚本快速更新"
+    safe_push(msg)


### PR DESCRIPTION
## Summary
- 优化 `safe_push.py`，支持自动添加、提交并在推送前执行 `pull --rebase`
- 默认提交信息为“更新脚本快速更新”

## Testing
- `python -m py_compile scripts/safe_push.py`

------
https://chatgpt.com/codex/tasks/task_b_6847a7a86084832195e87e2f5bdd9686