### PR TITLE
实现缺失桩代码统计提示

### DIFF
--- a/code/core/stub_parser.py
+++ b/code/core/stub_parser.py
@@ -128,6 +128,9 @@ class StubParser:
         
         # YAML处理器
         self.yaml_handler = yaml_handler
+
+        # 用于统计缺失的桩代码锚点
+        self.missing_anchors: List[Dict[str, Any]] = []
     
     def set_yaml_handler(self, yaml_handler: YamlStubHandler):
         """
@@ -253,6 +256,7 @@ class StubParser:
                             )
                         else:
                             logger.warning(f"未找到锚点 {anchor_text} 对应的桩代码")
+                            self.missing_anchors.append({'file': file_path, 'line': i + 1, 'anchor': anchor_text})
                     else:
                         logger.warning(
                             f"锚点 '{anchor_text}' 格式不正确, 无法解析出三个部分 (TC_ID, STEP_ID, segment_ID)"

--- a/code/ui/app_controller.py
+++ b/code/ui/app_controller.py
@@ -460,6 +460,10 @@ class AppController:
                 self.log_info(f"文件总数: {result.get('total_files', 0)}")
                 self.log_info(f"处理成功文件: {result.get('processed_files', 0)}")
                 self.log_info(f"成功插入桩点: {result.get('successful_stubs', 0)}")
+
+                missing = result.get('missing_stubs', 0)
+                if missing > 0:
+                    self.log_warning(f"缺失桩代码锚点: {missing} 个")
                 
                 # 显示备份和结果目录信息
                 backup_dir = result.get('backup_dir', '')


### PR DESCRIPTION
## Summary
- 在 `StubParser` 中新增 `missing_anchors` 列表收集未匹配的锚点
- `StubProcessor` 统计缺失桩代码数量并在 UI 中提示
- UI 控制器读取 `missing_stubs` 并输出警告

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68496c0c7cac8321a524455b059a4d5e