### PR TITLE
Fix YAML export representer registration

### DIFF
--- a/code/core/stub_processor.py
+++ b/code/core/stub_processor.py
@@ -579,7 +579,7 @@ class StubProcessor:
             def literal_representer(dumper, data):
                 return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
 
-            yaml.add_representer(LiteralStr, literal_representer)
+            yaml.add_representer(LiteralStr, literal_representer, Dumper=yaml.SafeDumper)
 
             # 将代码段包装为LiteralStr，确保YAML使用|块格式
             formatted_dict: Dict[str, Dict[str, Dict[str, LiteralStr]]] = {}


### PR DESCRIPTION
## Summary
- register custom LiteralStr representer for SafeDumper

## Testing
- `pytest -q`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6849a84060608321a232c6d04b5e23cd