### PR TITLE
Add monthly budget feature

### DIFF
--- a/code/ui/__init__.py
+++ b/code/ui/__init__.py
@@ -6,3 +6,4 @@ __version__ = "1.0.0"
 from code.ui.app_ui import YAMLWeaveUI
 from code.ui.app_controller import AppController
 from code.ui.rounded_progressbar import RoundedProgressBar
+from code.ui.budget_window import BudgetWindow

--- a/code/ui/app_ui.py
+++ b/code/ui/app_ui.py
@@ -9,6 +9,7 @@ import sys
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox, scrolledtext
 from .rounded_progressbar import RoundedProgressBar
+from .budget_window import BudgetWindow
 import datetime
 import re
 from typing import Callable, Dict, List, Optional, Any, Tuple
@@ -78,6 +79,7 @@ class YAMLWeaveUI:
 
         help_menu = tk.Menu(menu_bar, tearoff=0)
         help_menu.add_command(label="关于", command=self._show_about)
+        help_menu.add_command(label="月度预算", command=self._open_budget)
         menu_bar.add_cascade(label="帮助", menu=help_menu)
         self.root.config(menu=menu_bar)
 
@@ -286,6 +288,13 @@ class YAMLWeaveUI:
         else:
             self.log("[错误] 未设置导出回调函数", tag="error")
             self.update_status("导出失败")
+
+    def _open_budget(self):
+        """打开月度预算窗口"""
+        if not hasattr(self, "budget_window") or not self.budget_window.winfo_exists():
+            self.budget_window = BudgetWindow(self.root)
+        else:
+            self.budget_window.lift()
     
     def _show_about(self):
         """显示关于对话框"""

--- a/code/ui/budget_window.py
+++ b/code/ui/budget_window.py
@@ -1,0 +1,48 @@
+import tkinter as tk
+from tkinter import ttk
+
+class BudgetWindow(tk.Toplevel):
+    """月度预算管理窗口"""
+
+    def __init__(self, master, total=0.0, used=0.0):
+        super().__init__(master)
+        self.title("月度预算")
+        self.total_var = tk.DoubleVar(value=total)
+        self.used_var = tk.DoubleVar(value=used)
+
+        self.style = ttk.Style(self)
+        self.style.configure("Card.TFrame", background="#1F1F1F")
+        self.style.configure("CardTitle.TLabel", font=("Segoe UI", 12, "bold"), foreground="#FFFFFF", background="#1F1F1F")
+        self.style.configure("CardSubtitle.TLabel", font=("Segoe UI", 10), foreground="#ffffff60", background="#1F1F1F")
+        self.style.configure(
+            "Card.Horizontal.TProgressbar",
+            troughcolor="#FFFFFF20",
+            background="#FFFFFF",
+            thickness=4,
+        )
+        self.style.configure("Card.TButton", font=("Segoe UI", 10), foreground="#ffffff", background="#1F1F1F", borderwidth=1)
+
+        frame = ttk.Frame(self, style="Card.TFrame", padding=(12, 8))
+        frame.pack(fill="both", expand=True)
+
+        ttk.Label(frame, text="本月预算", style="CardTitle.TLabel").grid(row=0, column=0, sticky="w")
+        self.total_entry = ttk.Entry(frame, textvariable=self.total_var, width=10)
+        self.total_entry.grid(row=0, column=1, padx=5, sticky="w")
+
+        ttk.Label(frame, text="已使用", style="CardSubtitle.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 2))
+        self.used_entry = ttk.Entry(frame, textvariable=self.used_var, width=10)
+        self.used_entry.grid(row=1, column=1, padx=5, sticky="w")
+
+        self.pb = ttk.Progressbar(frame, style="Card.Horizontal.TProgressbar", mode="determinate", length=200)
+        self.pb.grid(row=2, column=0, columnspan=2, pady=8, sticky="we")
+
+        self.update_progress()
+
+        ttk.Button(frame, text="更新", command=self.update_progress, style="Card.TButton").grid(row=3, column=0, columnspan=2, pady=4)
+
+    def update_progress(self):
+        total = self.total_var.get() or 0.0
+        used = self.used_var.get() or 0.0
+        pct = 0 if total == 0 else min(max(used / total * 100, 0), 100)
+        self.pb["value"] = pct
+        self.pb.update_idletasks()


### PR DESCRIPTION
## Summary
- add `BudgetWindow` for managing monthly budget
- open budget UI from menu
- export `BudgetWindow` in package

## Testing
- `python -m py_compile code/ui/budget_window.py code/ui/app_ui.py code/ui/__init__.py`

------
https://chatgpt.com/codex/tasks/task_b_684fda39cd4c8321a565b8f05b470f35